### PR TITLE
Auto-delete problematic files & some UI fixes

### DIFF
--- a/GTAIVDowngradeUtility/MainWindow.xaml
+++ b/GTAIVDowngradeUtility/MainWindow.xaml
@@ -9,13 +9,14 @@
         SizeToContent="WidthAndHeight"
         WindowStartupLocation="CenterScreen"
         Icon="/Assets/ivlogo.png"
+        SnapsToDevicePixels="True"
         ResizeMode="NoResize">
     <Grid>
         <StackPanel Margin="5,5,5,5" Grid.ColumnSpan="2">
             <TextBlock FontSize="28" TextWrapping="Wrap" HorizontalAlignment="Center">Gillian's GTA IV Downgrade Utility</TextBlock>
-            <TextBlock x:Name="directorytxt" HorizontalAlignment="Left" Margin="0,5,0,0" TextWrapping="Wrap" Text="Set your game directory before using:" VerticalAlignment="Top" FontWeight="SemiBold" TextDecorations="Underline"/>
+            <TextBlock x:Name="directorytxt" HorizontalAlignment="Left" Margin="0,0,0,2" TextWrapping="Wrap" Text="Set your game directory before using:" VerticalAlignment="Top" FontWeight="SemiBold" TextDecorations="Underline"/>
             <StackPanel Orientation="Horizontal">
-                <TextBox HorizontalAlignment="Left" x:Name="gamedirectory" Margin="0,2,0,0" VerticalAlignment="Top" Width="354" IsEnabled="False"/>
+                <TextBox HorizontalAlignment="Left" x:Name="gamedirectory" Margin="0,0,0,0" VerticalAlignment="Top" Width="354" IsEnabled="False" Height='20'/>
                 <Button Content="Open..." HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" Width="60" Click="Button_Click"/>
             </StackPanel>
             <TextBlock Visibility="Collapsed" Margin="0,5,0,0" x:Name="tipsnote" FontSize="12" TextWrapping="Wrap" HorizontalAlignment="Center" TextDecorations="Underline">Keep the options at default values unless you know what you're doing.</TextBlock>

--- a/GTAIVDowngradeUtility/MainWindow.xaml
+++ b/GTAIVDowngradeUtility/MainWindow.xaml
@@ -14,10 +14,10 @@
     <Grid>
         <StackPanel Margin="5,5,5,5" Grid.ColumnSpan="2">
             <TextBlock FontSize="28" TextWrapping="Wrap" HorizontalAlignment="Center">Gillian's GTA IV Downgrade Utility</TextBlock>
-            <TextBlock x:Name="directorytxt" HorizontalAlignment="Left" Margin="0,0,0,2" TextWrapping="Wrap" Text="Set your game directory before using:" VerticalAlignment="Top" FontWeight="SemiBold" TextDecorations="Underline"/>
-            <StackPanel Orientation="Horizontal">
-                <TextBox HorizontalAlignment="Left" x:Name="gamedirectory" Margin="0,0,0,0" VerticalAlignment="Top" Width="354" IsEnabled="False" Height='20'/>
-                <Button Content="Open..." HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" Width="60" Click="Button_Click"/>
+            <TextBlock x:Name="directorytxt" HorizontalAlignment="Left" Margin="0,5,0,0" TextWrapping="Wrap" Text="Set your game directory before using:" VerticalAlignment="Top" FontWeight="SemiBold" TextDecorations="Underline"/>
+            <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                <TextBox HorizontalAlignment="Left" x:Name="gamedirectory" VerticalAlignment="Top" Width="354" IsEnabled="False" Height="20"/>
+                <Button Content="Open..." HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" Width="60" Click="Button_Click" Height="20"/>
             </StackPanel>
             <TextBlock Visibility="Collapsed" Margin="0,5,0,0" x:Name="tipsnote" FontSize="12" TextWrapping="Wrap" HorizontalAlignment="Center" TextDecorations="Underline">Keep the options at default values unless you know what you're doing.</TextBlock>
             <StackPanel Margin="0,5,0,0" Orientation="Horizontal" HorizontalAlignment="Center">

--- a/GTAIVDowngradeUtility/MainWindow.xaml.cs
+++ b/GTAIVDowngradeUtility/MainWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Configuration;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Security.Principal;
@@ -297,7 +298,7 @@ namespace GTAIVDowngradeUtilityWPF
                 zpatchcheckbox.Visibility = Visibility.Collapsed;
                 tipsnote.Visibility = Visibility.Collapsed;
             }
-            if (tipscheck.IsChecked == true)
+            if (tipscheck.IsChecked == true && advancedcheck.IsChecked == true)
             {
                 Logger.Debug(" Displaying a tip...");
                 MessageBox.Show("Advanced Mode enables all toggles. They're hidden by default as the defaults for these options are fine for majority.\n\nDon't touch these toggles if you have no idea what you're doing and read the tips.");
@@ -675,6 +676,10 @@ namespace GTAIVDowngradeUtilityWPF
             if (Directory.Exists($"{directory}\\plugins"))
             {
                 Directory.Delete($"{directory}\\plugins", true);
+            }
+            foreach (var file in from dll in new string[4] { "launc.dll", "orig_socialclub.dll", "socialclub.dll", "1911.dll" } where File.Exists($"{directory}\\{dll}") select dll)
+            {
+                File.Delete($"{directory}\\{file}");
             }
 
             // actually downgrading now


### PR DESCRIPTION
## Changes
- Auto-delete ``launc.dll``, ``socailclub.dll``, ``orig_socialclub.dll`` and ``1911.dll`` as they may cause the game not to start after downgrading.
- Fix vertical black line at the right edge of the window.
- Fix inconsistent height between the game directory TextBox and "Open" Button
- Do not show advanced mode tip when disabling the checkbox.